### PR TITLE
Few fixes to src/Makefile when building Fortran bindings

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -3,6 +3,7 @@ ifeq ($(FORTRAN),1)
         OBJS    = mlog2.o client.o local_client.o data_store.o partitioner.o messages.o range_server.o mdhim_options.o mdhim_private.o indexes.o mdhim_fortran.o  mdhim_f90_binding.o
 else
         OBJS    = mlog2.o client.o local_client.o data_store.o partitioner.o messages.o range_server.o mdhim_options.o mdhim_private.o indexes.o
+endif
 
 ifeq ($(LEVELDB),1)
 	OBJS += ds_leveldb.o
@@ -23,7 +24,7 @@ mdhim.o: mdhim.c $(OBJS)
 	$(CC) -c $< $(CINC) $(CLIBS) -lleveldb
 
 mdhim_fortran.o: mdhim_fortran.c
-        $(CC) -c $< $(CINC) $(CLIBS)
+	$(CC) -c $< $(CINC) $(CLIBS)
 
 mlog2.o: Mlog2/mlog2.c
 	$(CC) -c $^ $(CINC) $(CLIBS) -lleveldb
@@ -65,7 +66,7 @@ mdhim_options.o : mdhim_options.c
 	$(CC) -c $^ $(CINC) $(CLIBS) -lleveldb
 
 mdhim_f90_binding.o: mdhim_f90_binding.f90
-        $(FF) -c $< $(FINC) $(FLIBS)
+	$(FF) -c $< $(FINC) $(FLIBS)
 
 lib:	
 	ar rvs libmdhim.a mdhim.o $(OBJS)


### PR DESCRIPTION
A couple of fixes to src/Makefile when building Fortran bindings.
There was a missing endif and spaces instead of TAB in a couple of fortran targets.
Specifically, the errors that one was getting when building fortran targets where:
1) Error --> Makefile:78: *** missing 'endif'.  Stop.
2) Error --> Makefile:27: *** missing separator
   (did you mean TAB instead of 8 spaces?).Stop.
3) Makefile:69: *** missing separator
   (did you mean TAB instead of 8 spaces?).  Stop.